### PR TITLE
Add skeleton for the generic message structure for cloud events

### DIFF
--- a/src/Likvido.Worker.AzureStorageQueue.csproj
+++ b/src/Likvido.Worker.AzureStorageQueue.csproj
@@ -24,8 +24,4 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.9" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.4.2" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="MessageFormats\" />
-  </ItemGroup>
 </Project>

--- a/src/Likvido.Worker.AzureStorageQueue.csproj
+++ b/src/Likvido.Worker.AzureStorageQueue.csproj
@@ -25,4 +25,7 @@
     <PackageReference Include="Azure.Storage.Queues" Version="12.4.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="MessageFormats\" />
+  </ItemGroup>
 </Project>

--- a/src/Likvido.Worker.AzureStorageQueue.sln
+++ b/src/Likvido.Worker.AzureStorageQueue.sln
@@ -5,7 +5,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Likvido.Worker.AzureStorage
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Folder", "Solution Folder", "{A4257B99-86E2-4F0D-A3C2-CF7252D7F852}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\nuget.yml = .github\workflows\nuget.yml
+		..\.github\workflows\nuget.yml = ..\.github\workflows\nuget.yml
+		..\version.props = ..\version.props
+		..\README.md = ..\README.md
+		..\LICENSE = ..\LICENSE
 	EndProjectSection
 EndProject
 Global

--- a/src/MessageFormats/CloudEvent.cs
+++ b/src/MessageFormats/CloudEvent.cs
@@ -2,6 +2,10 @@
 
 namespace Likvido.Worker.AzureStorageQueue.MessageFormats
 {
+    /// <summary>
+    /// Implementation of a cloud event, using v1.0
+    /// Spec: https://github.com/cloudevents/spec/blob/v1.0/spec.md
+    /// </summary>
     public class CloudEvent
     {
         public string Id { get; set; } = null!;

--- a/src/MessageFormats/CloudEvent.cs
+++ b/src/MessageFormats/CloudEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace Likvido.Worker.AzureStorageQueue.MessageFormats
+{
+    public class CloudEvent<TMessage>
+    {
+        public string Id { get; set; } = null!;
+        public string Source { get; set; } = null!;
+        public TMessage Data { get; set; } = default!;
+        public string Type { get; set; } = null!;
+        public DateTime Time { get; set; }
+        public string SpecVersion { get; set; } = null!;
+    }
+}

--- a/src/MessageFormats/CloudEvent.cs
+++ b/src/MessageFormats/CloudEvent.cs
@@ -1,13 +1,18 @@
 ﻿using System;
+
 namespace Likvido.Worker.AzureStorageQueue.MessageFormats
 {
-    public class CloudEvent<TMessage>
+    public class CloudEvent
     {
         public string Id { get; set; } = null!;
         public string Source { get; set; } = null!;
-        public TMessage Data { get; set; } = default!;
         public string Type { get; set; } = null!;
-        public DateTime Time { get; set; }
+        public DateTime? Time { get; set; }
         public string SpecVersion { get; set; } = null!;
+    }
+
+    public class CloudEvent<TMessage> : CloudEvent
+    {
+        public TMessage Data { get; set; } = default!;
     }
 }

--- a/version.props
+++ b/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This adds a class that can be used by the robots, if they are listening for queues that contains CloudEvent (https://cloudevents.io/) messages.

They would then create a message processor like this:

```
public class MessageProcessor : IMessageProcessor<CloudEvent<MyCustomMessage>>
{
    private readonly ILogger<Worker> logger;

    public Worker(ILogger<Worker> logger)
    {
        this.logger = logger;
    }

    public async Task ProcessMessage(CloudEvent<MyCustomMessage> cloudEvent, CancellationToken stoppingToken)
    {
        var myCustomMessage = cloudEvent.Data;
        // TODO: Process the message
    }
}
```