### PR TITLE
Made possible to configure avoidMessageSampling without configureTelemetry

### DIFF
--- a/version.props
+++ b/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.5.1</Version>
+    <Version>1.6.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Related to https://github.com/Likvido/Likvido.DocumentReader.Api/pull/48#issuecomment-826648320
Will use `services.AddApplicationInsightsTelemetry();` and pass `configureTelemetry: false` to `services.AddMessageProcessor`